### PR TITLE
making the package typing compliance 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 dist
+build
+*.egg-info

--- a/pkce/__init__.py
+++ b/pkce/__init__.py
@@ -1,4 +1,4 @@
-"""Simple module to generate PKCE code verifier and code challenge.
+'''Simple module to generate PKCE code verifier and code challenge.
 
 Examples
 --------
@@ -8,7 +8,7 @@ Examples
 >>> import pkce
 >>> code_verifier = pkce.generate_code_verifier(length=128)
 >>> code_challenge = pkce.get_code_challenge(code_verifier)
-"""
+'''
 
 import secrets
 import hashlib
@@ -16,7 +16,7 @@ import base64
 
 
 def generate_code_verifier(length: int = 128) -> str:
-    """Return a random PKCE-compliant code verifier.
+    '''Return a random PKCE-compliant code verifier.
 
     Parameters
     ----------
@@ -32,7 +32,7 @@ def generate_code_verifier(length: int = 128) -> str:
     ------
     ValueError
         When `43 <= length <= 128` is not verified.
-    """
+    '''
     if not 43 <= length <= 128:
         msg = 'Parameter `length` must verify `43 <= length <= 128`.'
         raise ValueError(msg)
@@ -41,7 +41,7 @@ def generate_code_verifier(length: int = 128) -> str:
 
 
 def generate_pkce_pair(code_verifier_length: int = 128) -> tuple:
-    """Return random PKCE-compliant code verifier and code challenge.
+    '''Return random PKCE-compliant code verifier and code challenge.
 
     Parameters
     ----------
@@ -58,7 +58,7 @@ def generate_pkce_pair(code_verifier_length: int = 128) -> tuple:
     ------
     ValueError
         When `43 <= code_verifier_length <= 128` is not verified.
-    """
+    '''
     if not 43 <= code_verifier_length <= 128:
         msg = 'Parameter `code_verifier_length` must verify '
         msg += '`43 <= code_verifier_length <= 128`.'
@@ -69,7 +69,7 @@ def generate_pkce_pair(code_verifier_length: int = 128) -> tuple:
 
 
 def get_code_challenge(code_verifier: str) -> str:
-    """Return the PKCE-compliant code challenge for a given verifier.
+    '''Return the PKCE-compliant code challenge for a given verifier.
 
     Parameters
     ----------
@@ -85,7 +85,7 @@ def get_code_challenge(code_verifier: str) -> str:
     ------
     ValueError
         When `43 <= len(code_verifier) <= 128` is not verified.
-    """
+    '''
     if not 43 <= len(code_verifier) <= 128:
         msg = 'Parameter `code_verifier` must verify '
         msg += '`43 <= len(code_verifier) <= 128`.'

--- a/pkce/__init__.py
+++ b/pkce/__init__.py
@@ -1,4 +1,4 @@
-'''Simple module to generate PKCE code verifier and code challenge.
+"""Simple module to generate PKCE code verifier and code challenge.
 
 Examples
 --------
@@ -8,7 +8,7 @@ Examples
 >>> import pkce
 >>> code_verifier = pkce.generate_code_verifier(length=128)
 >>> code_challenge = pkce.get_code_challenge(code_verifier)
-'''
+"""
 
 import secrets
 import hashlib
@@ -16,7 +16,7 @@ import base64
 
 
 def generate_code_verifier(length: int = 128) -> str:
-    '''Return a random PKCE-compliant code verifier.
+    """Return a random PKCE-compliant code verifier.
 
     Parameters
     ----------
@@ -32,7 +32,7 @@ def generate_code_verifier(length: int = 128) -> str:
     ------
     ValueError
         When `43 <= length <= 128` is not verified.
-    '''
+    """
     if not 43 <= length <= 128:
         msg = 'Parameter `length` must verify `43 <= length <= 128`.'
         raise ValueError(msg)
@@ -41,7 +41,7 @@ def generate_code_verifier(length: int = 128) -> str:
 
 
 def generate_pkce_pair(code_verifier_length: int = 128) -> tuple:
-    '''Return random PKCE-compliant code verifier and code challenge.
+    """Return random PKCE-compliant code verifier and code challenge.
 
     Parameters
     ----------
@@ -58,7 +58,7 @@ def generate_pkce_pair(code_verifier_length: int = 128) -> tuple:
     ------
     ValueError
         When `43 <= code_verifier_length <= 128` is not verified.
-    '''
+    """
     if not 43 <= code_verifier_length <= 128:
         msg = 'Parameter `code_verifier_length` must verify '
         msg += '`43 <= code_verifier_length <= 128`.'
@@ -69,7 +69,7 @@ def generate_pkce_pair(code_verifier_length: int = 128) -> tuple:
 
 
 def get_code_challenge(code_verifier: str) -> str:
-    '''Return the PKCE-compliant code challenge for a given verifier.
+    """Return the PKCE-compliant code challenge for a given verifier.
 
     Parameters
     ----------
@@ -85,7 +85,7 @@ def get_code_challenge(code_verifier: str) -> str:
     ------
     ValueError
         When `43 <= len(code_verifier) <= 128` is not verified.
-    '''
+    """
     if not 43 <= len(code_verifier) <= 128:
         msg = 'Parameter `code_verifier` must verify '
         msg += '`43 <= len(code_verifier) <= 128`.'

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,5 @@ setuptools.setup(
         'Operating System :: OS Independent',
     ],
     python_requires='>=3',
+    zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,14 @@ setuptools.setup(
     author_email='despres.romeo@gmail.com',
     description='PKCE Pyhton generator.',
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type='text/markdown',
     url='https://github.com/RomeoDespres/pkce',
+    package_data={'pkce': ['py.typed']},
     packages=['pkce'],
     classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
     ],
     python_requires='>=3',
 )


### PR DESCRIPTION
Hello again @RomeoDespres , in my previous commit I made the module typing compliance, I ran mypy and pylint and both tests passed. However, when I pull pcke 1.0.1 from pypi I was getting the same error as before, I did a little googling and I found out that typing in third party packages (key work package) require extra [steps](https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages) . I added an empty file in my local copy of pkce and the error went away. Please take some time to read the link that I sent you since I had to update setup.py (which I couldn't test).

One more thing, this time I made sure to replace all double quotes with single quotes, (my pylint changed again them and I didn't notice)